### PR TITLE
Token - fixed bug where Eth was not recognized

### DIFF
--- a/packages/core-sdk/token/src/query/ERC20/getDecimals.ts
+++ b/packages/core-sdk/token/src/query/ERC20/getDecimals.ts
@@ -3,9 +3,9 @@ import { Box } from "as-container";
 import { Ethereum_Connection, Ethereum_Query } from "../w3";
 
 export function getDecimals(address: string, connection: Ethereum_Connection): Box<i32> | null {
-  if (address.toLowerCase() === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") {
+  if (address.toLowerCase() == "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") {
     const network = Ethereum_Query.getNetwork({ connection }).unwrap();
-    return network.chainId === 1 ? Box.from(18) : null;
+    return network.chainId == 1 ? Box.from(18) : null;
   }
   const decimalsResult = Ethereum_Query.callContractView({
     address: address,

--- a/packages/core-sdk/token/src/query/ERC20/getName.ts
+++ b/packages/core-sdk/token/src/query/ERC20/getName.ts
@@ -2,9 +2,9 @@ import { hexToUtfStr } from "../utils";
 import { Ethereum_Connection, Ethereum_Query } from "../w3";
 
 export function getName(address: string, connection: Ethereum_Connection): string | null {
-  if (address.toLowerCase() === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") {
+  if (address.toLowerCase() == "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") {
     const network = Ethereum_Query.getNetwork({ connection }).unwrap();
-    return network.chainId === 1 ? "Ether" : null;
+    return network.chainId == 1 ? "Ether" : null;
   }
   const nameResult = Ethereum_Query.callContractView({
     address: address,

--- a/packages/core-sdk/token/src/query/ERC20/getSymbol.ts
+++ b/packages/core-sdk/token/src/query/ERC20/getSymbol.ts
@@ -2,9 +2,9 @@ import { hexToUtfStr } from "../utils";
 import { Ethereum_Connection, Ethereum_Query } from "../w3";
 
 export function getSymbol(address: string, connection: Ethereum_Connection): string | null {
-  if (address.toLowerCase() === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") {
+  if (address.toLowerCase() == "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") {
     const network = Ethereum_Query.getNetwork({ connection }).unwrap();
-    return network.chainId === 1 ? "ETH" : null;
+    return network.chainId == 1 ? "ETH" : null;
   }
   const symbolResult = Ethereum_Query.callContractView({
     address: address,

--- a/packages/core-sdk/token/src/query/ERC20/getTotalSupply.ts
+++ b/packages/core-sdk/token/src/query/ERC20/getTotalSupply.ts
@@ -7,9 +7,9 @@ export function getTotalSupply(
   address: string,
   connection: Ethereum_Connection,
 ): Box<BigInt> | null {
-  if (address.toLowerCase() === "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") {
+  if (address.toLowerCase() == "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") {
     const network = Ethereum_Query.getNetwork({ connection }).unwrap();
-    return network.chainId === 1 ? Box.from(BigInt.NEG_ONE) : null;
+    return network.chainId == 1 ? Box.from(BigInt.NEG_ONE) : null;
   }
   const totalSupplyResult = Ethereum_Query.callContractView({
     address: address,

--- a/packages/core-sdk/token/src/query/__tests__/e2e/integration.spec.ts
+++ b/packages/core-sdk/token/src/query/__tests__/e2e/integration.spec.ts
@@ -66,7 +66,7 @@ describe("Ethereum", () => {
               uri: coreEnsUri,
               query: {
                 connection: {
-                  networkNameOrChainId: "1",
+                  networkNameOrChainId: "MAINNET",
                 },
               },
             },
@@ -101,6 +101,21 @@ describe("Ethereum", () => {
         address: "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
         name: "Dai Stablecoin v1.0",
         symbol: "DAI",
+        decimals: 18,
+      });
+    });
+
+    test("ETH", async () => {
+      const response = await getToken(
+        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        TokenType.ERC20,
+      );
+      expect(response.errors).toBeFalsy();
+      expect(response.data).toBeTruthy();
+      expect(response.data?.getToken).toMatchObject({
+        address: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        name: "Ether",
+        symbol: "ETH",
         decimals: 18,
       });
     });


### PR DESCRIPTION
This PR fixes a bug in the Token package, wherein Eth was not recognized due to use of a reference equality test. This was likely a typo due to use of the same operator symbol for the reference equality test in AS and strict equality test in JS (i.e. `===`).